### PR TITLE
Fix TypeException reference

### DIFF
--- a/include/simplesquirrel/object.hpp
+++ b/include/simplesquirrel/object.hpp
@@ -25,6 +25,7 @@
 #include <squirrel.h>
 #include <unordered_map>
 
+#include "exceptions.hpp"
 #include "type.hpp"
 
 namespace ssq {
@@ -181,7 +182,7 @@ namespace ssq {
         template<typename T>
         T toPtrUnsafe() const {
             if (getType() != Type::INSTANCE) {
-                throw TypeException("bad cast", "INSTANCE", getTypeStr());
+                throw ssq::TypeException("bad cast", "INSTANCE", getTypeStr());
             }
             sq_pushobject(vm, obj);
             SQUserPointer val;


### PR DESCRIPTION
Fix Type Exception reference....


```
In file included from simplesquirrel/source/args.cpp:1:0:
simplesquirrel/source/../include/simplesquirrel/object.hpp: In member function ‘T ssq::Object::toPtrUnsafe() const’:
simplesquirrel/source/../include/simplesquirrel/object.hpp:184:28: error: ‘TypeException’ is not a member of ‘ssq’
                 throw ssq::TypeException("bad cast", "INSTANCE", getTypeStr());
```