### PR TITLE
Fix invalid conversion of SQUnsignedIntegers

### DIFF
--- a/source/function.cpp
+++ b/source/function.cpp
@@ -21,8 +21,8 @@ namespace ssq {
     }
 
     unsigned int Function::getNumOfParams() const {
-        SQUnsignedInteger nparams;
-        SQUnsignedInteger nfreevars;
+        SQInteger nparams;
+        SQInteger nfreevars;
         sq_pushobject(vm, obj);
         if (SQ_FAILED(sq_getclosureinfo(vm, -1, &nparams, &nfreevars))) {
             sq_pop(vm, 1);


### PR DESCRIPTION
```
In file included from /simplesquirrel/source/../include/simplesquirrel/object.hpp:25:0,
                 from /simplesquirrel/source/../include/simplesquirrel/function.hpp:5,
                 from /simplesquirrel/source/function.cpp:1:
/simplesquirrel/source/function.cpp: In member function ‘unsigned int ssq::Function::getNumOfParams() const’:
/simplesquirrel/source/function.cpp:27:59: error: invalid conversion from ‘SQUnsignedInteger* {aka long long unsigned int*}’ to ‘SQInteger* {aka long long int*}’ [-fpermissive]
         if (SQ_FAILED(sq_getclosureinfo(vm, -1, &nparams, &nfreevars))) {
```

Switching the variables to SQIntegers fixes the definitions.